### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -180,7 +180,7 @@ services:
   # * layer 2 components - dependent on layer 0,1 components
   # event bus
   kafka:
-    image: bitnami/kafka:4.0.0
+    image: soldevelo/kafka:4.0.0
     deploy:
       replicas: 1
       resources:


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/kafka:4.0.0` → [`soldevelo/kafka:4.0.0`](https://hub.docker.com/r/soldevelo/kafka)